### PR TITLE
Add new widget SecureAppSwitcher to hide all app screens and to add flag `allowAndroidScreenshot`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,41 @@ SecureAppSwitcher.on();
 SecureAppSwitcher.off();
 ```
 
+### Use functions for all screens
+
+Wrap the `MaterialApp` widget with a `SecureAppSwitcherLayer`.
+
+```dart
+@override
+  Widget build(BuildContext context) {
+    return SecureAppSwitcherLayer(
+      allowAndroidScreenshot: true,
+      child: MaterialApp(
+        title: 'Secure App Switcher',
+        initialRoute: '/',
+      ),
+    );
+  }
+```
+
+Or use it with a `builder`:
+
+```dart
+@override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Secure App Switcher',
+      initialRoute: '/',
+      builder: (context, child) {
+        return SecureAppSwitcherLayer(
+          child: child ?? const CircularProgressIndicator(),
+        );
+      },
+    );
+  }
+```
+
+
 ### Use functions on specific screens
 
 It is necessary to set `secureAppSwitcherRouteObserver` to switch the function at the time of screen transition.

--- a/lib/secure_app_switcher.dart
+++ b/lib/secure_app_switcher.dart
@@ -1,4 +1,5 @@
 library secure_app_switcher;
 
 export 'src/secure_app_switcher.dart';
+export 'src/secure_app_switcher_layer.dart';
 export 'src/secure_app_switcher_page.dart';

--- a/lib/src/secure_app_switcher.dart
+++ b/lib/src/secure_app_switcher.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/services.dart';
 
+/// {@template SecureMaskStyle}
 /// Select a screen mask style.
 ///
 /// Applies to iOS only
+/// {@endtemplate}
 enum SecureMaskStyle {
   /// UIColor.white is applied.
   light,

--- a/lib/src/secure_app_switcher_layer.dart
+++ b/lib/src/secure_app_switcher_layer.dart
@@ -4,10 +4,21 @@ import 'package:flutter/material.dart';
 import 'package:secure_app_switcher/secure_app_switcher.dart';
 
 class SecureAppSwitcherLayer extends StatefulWidget {
+  /// A flag that controls Android screenshot behavior.
+  ///
+  /// When set to `true`, Android's `FLAG_SECURE` flag is cleared when the app is in the [AppLifecycleState.resumed] state, allowing for screenshots. The flag is set back to prevent screenshots at other times.
   final bool allowAndroidScreenshot;
   final SecureMaskStyle style;
   final Widget child;
 
+  /// Hides the app screen when user enters the app switcher.
+  ///
+  /// This widget is designed to be used as the root widget when you want to hide all screens of the app. It provides an option to allow screenshots on Android.
+  ///
+  /// In case you want to hide specific screens, use [SecureAppSwitcherPage] instead.
+  ///
+  /// [allowAndroidScreenshot] determines whether Android screenshots are allowed.
+  /// [style] sets the mask style for iOS. It defaults to [SecureMaskStyle.light].
   const SecureAppSwitcherLayer({
     super.key,
     this.allowAndroidScreenshot = false,

--- a/lib/src/secure_app_switcher_layer.dart
+++ b/lib/src/secure_app_switcher_layer.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:secure_app_switcher/secure_app_switcher.dart';
+
+class SecureAppSwitcherLayer extends StatefulWidget {
+  final bool allowAndroidScreenshot;
+  final SecureMaskStyle style;
+  final Widget child;
+
+  const SecureAppSwitcherLayer({
+    super.key,
+    this.allowAndroidScreenshot = false,
+    this.style = SecureMaskStyle.light,
+    required this.child,
+  });
+
+  @override
+  State<SecureAppSwitcherLayer> createState() => _SecureAppSwitcherLayerState();
+}
+
+class _SecureAppSwitcherLayerState extends State<SecureAppSwitcherLayer>
+    with WidgetsBindingObserver {
+  bool get isAndroidWithScreenshotAllowed =>
+      Platform.isAndroid && widget.allowAndroidScreenshot;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+
+    if (!isAndroidWithScreenshotAllowed) {
+      SecureAppSwitcher.on(iosStyle: widget.style);
+    } else {
+      SecureAppSwitcher.off();
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    super.didChangeAppLifecycleState(state);
+
+    if (!isAndroidWithScreenshotAllowed) return;
+
+    if (state == AppLifecycleState.resumed) {
+      SecureAppSwitcher.off();
+    } else {
+      SecureAppSwitcher.on(iosStyle: widget.style);
+    }
+  }
+
+  @override
+  void dispose() {
+    SecureAppSwitcher.off();
+
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}

--- a/lib/src/secure_app_switcher_layer.dart
+++ b/lib/src/secure_app_switcher_layer.dart
@@ -8,6 +8,8 @@ class SecureAppSwitcherLayer extends StatefulWidget {
   ///
   /// When set to `true`, Android's `FLAG_SECURE` flag is cleared when the app is in the [AppLifecycleState.resumed] state, allowing for screenshots. The flag is set back to prevent screenshots at other times.
   final bool allowAndroidScreenshot;
+
+  /// {@macro SecureMaskStyle}
   final SecureMaskStyle style;
   final Widget child;
 

--- a/lib/src/secure_app_switcher_page.dart
+++ b/lib/src/secure_app_switcher_page.dart
@@ -29,6 +29,8 @@ class SecureAppSwitcherPage extends StatefulWidget {
   }) : super(key: key);
 
   final Widget child;
+
+  /// {@macro SecureMaskStyle}
   final SecureMaskStyle style;
 
   @override


### PR DESCRIPTION
I've added this new widget mostly to allow Android screenshots, but it also seemed a convenient way to hide all screens all at once. If everything is okay, I could open another PR adding the same functionality to `SecureAppSwitcherPage` as well.

Feel free to suggest any changes, including the name of the new widget. I wasn't so sure of it when I came up with it.

Thanks in advance!