### PR TITLE
Add namespace to android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
+    namespace 'com.arkwycr.secure_app_switcher'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Fixes compile error with gradle 8.

To test this add this to pubspec.yaml:
```
  secure_app_switcher: #^0.1.0+1
    git: https://github.com/Hedon-dev/secure_app_switcher
```